### PR TITLE
Initialize project structure with formatting and CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
+    hooks:
+      - id: ruff
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: format lint test run-example
+
+format:
+	black .
+	ruff check --fix .
+
+lint:
+	pre-commit run --all-files
+
+test:
+	pytest
+
+run-example:
+	python example.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # FinFixer
+
+## Development
+
+Install dependencies (if using `pip`):
+
+```bash
+pip install -e .
+pre-commit install
+```
+
+## Commands
+
+- `make format` – format code with Black and Ruff
+- `make lint` – run pre-commit hooks
+- `make test` – run pytest suite
+- `make run-example` – execute example script

--- a/example.py
+++ b/example.py
@@ -1,0 +1,9 @@
+"""Example script for run-example target."""
+
+
+def main() -> None:
+    print("Hello, FinFixer!")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=67.6"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "finfixer"
+version = "0.1.0"
+description = "FinFixer project"
+readme = "README.md"
+authors = [{name = "Example", email = "example@example.com"}]
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic",
+    "jsonschema",
+    "jinja2",
+    "pandas",
+    "python-dateutil",
+    "pdfplumber",
+    "pytesseract",
+    "opencv-python",
+    "requests",
+    "tenacity",
+    "networkx",
+    "orjson",
+    "pytest",
+    "ruff",
+    "black",
+]
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from example import main
+
+
+def test_main(capsys):
+    main()
+    captured = capsys.readouterr()
+    assert "Hello" in captured.out


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with project dependencies and tool configs
- configure pre-commit for Ruff and Black
- introduce Makefile with format, lint, test and example targets
- include simple example script and test suite
- document usage in README

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c56864bf1483228854a3b20e9f9153