### PR TITLE
Add JSON schemas and validation tests

### DIFF
--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,3 @@
+"""Core package for schemas and related utilities."""
+
+__all__ = []

--- a/src/core/schemas/__init__.py
+++ b/src/core/schemas/__init__.py
@@ -1,0 +1,25 @@
+"""Load JSON schemas for SGR sections."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+
+SCHEMA_NAMES = [
+    "business_overview",
+    "legal_structure",
+    "financials",
+    "legal_cases",
+    "news",
+    "assets_gallery",
+    "container",
+]
+
+SCHEMAS: dict[str, dict] = {}
+for name in SCHEMA_NAMES:
+    with (BASE_DIR / f"{name}.schema.json").open(encoding="utf-8") as f:
+        SCHEMAS[name] = json.load(f)
+
+__all__ = ["SCHEMAS", "SCHEMA_NAMES"]

--- a/src/core/schemas/assets_gallery.schema.json
+++ b/src/core/schemas/assets_gallery.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["assets", "source", "confidence"],
+  "properties": {
+    "assets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["description", "url"],
+        "properties": {
+          "description": {"type": "string"},
+          "url": {"type": "string", "format": "uri"},
+          "valuation": {"type": "number", "minimum": 0}
+        }
+      }
+    },
+    "source": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  }
+}

--- a/src/core/schemas/business_overview.schema.json
+++ b/src/core/schemas/business_overview.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "company_name",
+    "inn",
+    "ogrn",
+    "registration_date",
+    "source",
+    "confidence"
+  ],
+  "properties": {
+    "company_name": {"type": "string"},
+    "inn": {"type": "string", "pattern": "^\\d{10}$"},
+    "ogrn": {"type": "string", "pattern": "^\\d{13}$"},
+    "registration_date": {"type": "string", "format": "date"},
+    "source": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  }
+}

--- a/src/core/schemas/container.schema.json
+++ b/src/core/schemas/container.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "business_overview",
+    "legal_structure",
+    "financials",
+    "legal_cases",
+    "news",
+    "assets_gallery",
+    "source",
+    "confidence"
+  ],
+  "properties": {
+    "business_overview": {"$ref": "business_overview.schema.json"},
+    "legal_structure": {"$ref": "legal_structure.schema.json"},
+    "financials": {"$ref": "financials.schema.json"},
+    "legal_cases": {"$ref": "legal_cases.schema.json"},
+    "news": {"$ref": "news.schema.json"},
+    "assets_gallery": {"$ref": "assets_gallery.schema.json"},
+    "source": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  }
+}

--- a/src/core/schemas/financials.schema.json
+++ b/src/core/schemas/financials.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["revenue", "profit", "reporting_date", "source", "confidence"],
+  "properties": {
+    "revenue": {"type": "number", "minimum": 0},
+    "profit": {"type": "number"},
+    "reporting_date": {"type": "string", "format": "date"},
+    "source": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  }
+}

--- a/src/core/schemas/legal_cases.schema.json
+++ b/src/core/schemas/legal_cases.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["cases", "source", "confidence"],
+  "properties": {
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["case_number", "decision_date", "status"],
+        "properties": {
+          "case_number": {"type": "string"},
+          "decision_date": {"type": "string", "format": "date"},
+          "status": {"type": "string", "enum": ["open", "closed"]}
+        }
+      }
+    },
+    "source": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  }
+}

--- a/src/core/schemas/legal_structure.schema.json
+++ b/src/core/schemas/legal_structure.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["owners", "source", "confidence"],
+  "properties": {
+    "owners": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "share"],
+        "properties": {
+          "name": {"type": "string"},
+          "share": {"type": "number", "minimum": 0, "maximum": 100}
+        }
+      }
+    },
+    "source": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  }
+}

--- a/src/core/schemas/news.schema.json
+++ b/src/core/schemas/news.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["items", "source", "confidence"],
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["headline", "date"],
+        "properties": {
+          "headline": {"type": "string"},
+          "date": {"type": "string", "format": "date"}
+        }
+      }
+    },
+    "source": {"type": "string"},
+    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  }
+}

--- a/tests/test_schemas_valid.py
+++ b/tests/test_schemas_valid.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import jsonschema
+import pytest
+
+# allow importing from src
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from core.schemas import SCHEMAS  # noqa: E402
+
+SCHEMA_DIR = Path(__file__).resolve().parents[1] / "src" / "core" / "schemas"
+
+
+def _resolver(name: str) -> jsonschema.RefResolver:
+    schema_path = SCHEMA_DIR / f"{name}.schema.json"
+    return jsonschema.RefResolver(base_uri=schema_path.as_uri(), referrer=SCHEMAS[name])
+
+
+FORMAT_CHECKER = jsonschema.FormatChecker()
+
+
+EXAMPLES = {
+    "business_overview": {
+        "valid": [
+            {
+                "company_name": "ABC Ltd",
+                "inn": "1234567890",
+                "ogrn": "1234567890123",
+                "registration_date": "2020-01-01",
+                "source": "registry",
+                "confidence": 0.9,
+            },
+            {
+                "company_name": "XYZ LLC",
+                "inn": "9876543210",
+                "ogrn": "9876543210987",
+                "registration_date": "2021-12-31",
+                "source": "registry",
+                "confidence": 0.8,
+            },
+            {
+                "company_name": "Foo Bar",
+                "inn": "1020304050",
+                "ogrn": "1231231231231",
+                "registration_date": "2022-05-20",
+                "source": "manual",
+                "confidence": 1,
+            },
+        ],
+        "invalid": [
+            {
+                "company_name": "Bad Inn",
+                "inn": "12345",
+                "ogrn": "1234567890123",
+                "registration_date": "2020-01-01",
+                "source": "registry",
+                "confidence": 0.9,
+            },
+            {
+                "company_name": "Missing OGRN",
+                "inn": "1234567890",
+                "registration_date": "2020-01-01",
+                "source": "registry",
+                "confidence": 0.9,
+            },
+            {
+                "company_name": "Bad Date",
+                "inn": "1234567890",
+                "ogrn": "1234567890123",
+                "registration_date": "01-01-2020",
+                "source": "registry",
+                "confidence": 0.9,
+            },
+        ],
+    },
+    "legal_structure": {
+        "valid": [
+            {
+                "owners": [
+                    {"name": "Owner1", "share": 60},
+                    {"name": "Owner2", "share": 40},
+                ],
+                "source": "statements",
+                "confidence": 0.7,
+            },
+            {
+                "owners": [{"name": "Owner", "share": 100}],
+                "source": "statements",
+                "confidence": 1,
+            },
+            {
+                "owners": [
+                    {"name": "A", "share": 33.3},
+                    {"name": "B", "share": 66.7},
+                ],
+                "source": "registry",
+                "confidence": 0.5,
+            },
+        ],
+        "invalid": [
+            {
+                "owners": [{"name": "Owner1", "share": 150}],
+                "source": "statements",
+                "confidence": 0.7,
+            },
+            {
+                "owners": [{"share": 50}],
+                "source": "statements",
+                "confidence": 0.7,
+            },
+            {
+                "source": "statements",
+                "confidence": 0.7,
+            },
+        ],
+    },
+    "financials": {
+        "valid": [
+            {
+                "revenue": 1000,
+                "profit": 100,
+                "reporting_date": "2023-12-31",
+                "source": "report",
+                "confidence": 0.9,
+            },
+            {
+                "revenue": 0,
+                "profit": 0,
+                "reporting_date": "2022-06-30",
+                "source": "report",
+                "confidence": 0.8,
+            },
+            {
+                "revenue": 500,
+                "profit": -50,
+                "reporting_date": "2021-01-01",
+                "source": "audit",
+                "confidence": 0.6,
+            },
+        ],
+        "invalid": [
+            {
+                "revenue": -1,
+                "profit": 10,
+                "reporting_date": "2023-12-31",
+                "source": "report",
+                "confidence": 0.9,
+            },
+            {
+                "revenue": 100,
+                "profit": 10,
+                "source": "report",
+                "confidence": 0.9,
+            },
+            {
+                "revenue": 100,
+                "profit": 10,
+                "reporting_date": "31-12-2023",
+                "source": "report",
+                "confidence": 0.9,
+            },
+        ],
+    },
+    "legal_cases": {
+        "valid": [
+            {
+                "cases": [
+                    {
+                        "case_number": "A1",
+                        "decision_date": "2023-03-01",
+                        "status": "open",
+                    }
+                ],
+                "source": "courts",
+                "confidence": 0.4,
+            },
+            {
+                "cases": [
+                    {
+                        "case_number": "B2",
+                        "decision_date": "2020-11-15",
+                        "status": "closed",
+                    }
+                ],
+                "source": "courts",
+                "confidence": 0.8,
+            },
+            {
+                "cases": [
+                    {
+                        "case_number": "C3",
+                        "decision_date": "2022-07-07",
+                        "status": "open",
+                    },
+                    {
+                        "case_number": "D4",
+                        "decision_date": "2021-05-05",
+                        "status": "closed",
+                    },
+                ],
+                "source": "courts",
+                "confidence": 0.9,
+            },
+        ],
+        "invalid": [
+            {
+                "cases": [
+                    {
+                        "case_number": "E5",
+                        "decision_date": "2023-01-01",
+                        "status": "pending",
+                    }
+                ],
+                "source": "courts",
+                "confidence": 0.5,
+            },
+            {
+                "cases": [{"decision_date": "2023-01-01", "status": "open"}],
+                "source": "courts",
+                "confidence": 0.5,
+            },
+            {
+                "source": "courts",
+                "confidence": 0.5,
+            },
+        ],
+    },
+    "news": {
+        "valid": [
+            {
+                "items": [{"headline": "News 1", "date": "2023-01-01"}],
+                "source": "media",
+                "confidence": 0.7,
+            },
+            {
+                "items": [
+                    {"headline": "News 2", "date": "2022-12-12"},
+                    {"headline": "News 3", "date": "2022-12-13"},
+                ],
+                "source": "media",
+                "confidence": 0.6,
+            },
+            {
+                "items": [{"headline": "Another", "date": "2020-05-05"}],
+                "source": "media",
+                "confidence": 1,
+            },
+        ],
+        "invalid": [
+            {
+                "items": [{"date": "2023-01-01"}],
+                "source": "media",
+                "confidence": 0.7,
+            },
+            {
+                "items": [{"headline": "Bad Date", "date": "01-01-2023"}],
+                "source": "media",
+                "confidence": 0.7,
+            },
+            {
+                "source": "media",
+                "confidence": 0.7,
+            },
+        ],
+    },
+    "assets_gallery": {
+        "valid": [
+            {
+                "assets": [
+                    {
+                        "description": "Car",
+                        "url": "http://example.com/car.jpg",
+                        "valuation": 10000,
+                    }
+                ],
+                "source": "inventory",
+                "confidence": 0.9,
+            },
+            {
+                "assets": [
+                    {
+                        "description": "House",
+                        "url": "https://example.com/house.png",
+                    }
+                ],
+                "source": "inventory",
+                "confidence": 0.8,
+            },
+            {
+                "assets": [
+                    {
+                        "description": "Boat",
+                        "url": "http://example.com/boat.jpg",
+                        "valuation": 0,
+                    }
+                ],
+                "source": "inventory",
+                "confidence": 0.6,
+            },
+        ],
+        "invalid": [
+            {
+                "assets": [{"description": "Car", "valuation": 10000}],
+                "source": "inventory",
+                "confidence": 0.9,
+            },
+            {
+                "assets": [
+                    {
+                        "description": "Car",
+                        "url": "http://example.com/car.jpg",
+                        "valuation": -100,
+                    }
+                ],
+                "source": "inventory",
+                "confidence": 0.9,
+            },
+            {
+                "source": "inventory",
+                "confidence": 0.9,
+            },
+        ],
+    },
+}
+
+# build container examples using previous ones
+EXAMPLES["container"] = {
+    "valid": [
+        {
+            "business_overview": EXAMPLES["business_overview"]["valid"][0],
+            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
+            "financials": EXAMPLES["financials"]["valid"][0],
+            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
+            "news": EXAMPLES["news"]["valid"][0],
+            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
+            "source": "container",
+            "confidence": 0.9,
+        },
+        {
+            "business_overview": EXAMPLES["business_overview"]["valid"][1],
+            "legal_structure": EXAMPLES["legal_structure"]["valid"][1],
+            "financials": EXAMPLES["financials"]["valid"][1],
+            "legal_cases": EXAMPLES["legal_cases"]["valid"][1],
+            "news": EXAMPLES["news"]["valid"][1],
+            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][1],
+            "source": "container",
+            "confidence": 0.8,
+        },
+        {
+            "business_overview": EXAMPLES["business_overview"]["valid"][2],
+            "legal_structure": EXAMPLES["legal_structure"]["valid"][2],
+            "financials": EXAMPLES["financials"]["valid"][2],
+            "legal_cases": EXAMPLES["legal_cases"]["valid"][2],
+            "news": EXAMPLES["news"]["valid"][2],
+            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][2],
+            "source": "container",
+            "confidence": 1,
+        },
+    ],
+    "invalid": [
+        {
+            # missing news
+            "business_overview": EXAMPLES["business_overview"]["valid"][0],
+            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
+            "financials": EXAMPLES["financials"]["valid"][0],
+            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
+            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
+            "source": "container",
+            "confidence": 0.9,
+        },
+        {
+            # invalid business_overview
+            "business_overview": EXAMPLES["business_overview"]["invalid"][0],
+            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
+            "financials": EXAMPLES["financials"]["valid"][0],
+            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
+            "news": EXAMPLES["news"]["valid"][0],
+            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
+            "source": "container",
+            "confidence": 0.9,
+        },
+        {
+            # confidence out of range
+            "business_overview": EXAMPLES["business_overview"]["valid"][0],
+            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
+            "financials": EXAMPLES["financials"]["valid"][0],
+            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
+            "news": EXAMPLES["news"]["valid"][0],
+            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
+            "source": "container",
+            "confidence": 1.5,
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize(
+    "schema_name, example",
+    [(name, ex) for name, data in EXAMPLES.items() for ex in data["valid"]],
+)
+def test_valid_examples(schema_name: str, example: dict) -> None:
+    resolver = _resolver(schema_name)
+    jsonschema.validate(
+        example,
+        SCHEMAS[schema_name],
+        resolver=resolver,
+        format_checker=FORMAT_CHECKER,
+    )
+
+
+@pytest.mark.parametrize(
+    "schema_name, example",
+    [(name, ex) for name, data in EXAMPLES.items() for ex in data["invalid"]],
+)
+def test_invalid_examples(schema_name: str, example: dict) -> None:
+    resolver = _resolver(schema_name)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            example,
+            SCHEMAS[schema_name],
+            resolver=resolver,
+            format_checker=FORMAT_CHECKER,
+        )


### PR DESCRIPTION
## Summary
- define strict JSON schemas for business overview, legal structure, financials, legal cases, news, assets gallery, and container sections
- load schemas via `core.schemas` index
- cover each schema with tests for valid and invalid examples

## Testing
- `python -m black --check src tests`
- `ruff check src tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c569928c088322bd112f440ea7eabd