### PR TITLE
feat: package JSON schemas and loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,11 @@
 [build-system]
-requires = ["setuptools>=67.6"]
+requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "finfixer"
+name = "company-report"
 version = "0.1.0"
-description = "FinFixer project"
-readme = "README.md"
-authors = [{name = "Example", email = "example@example.com"}]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "pydantic",
     "jsonschema",
@@ -27,9 +24,20 @@ dependencies = [
     "black",
 ]
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = [
+  "core",
+  "core.schemas",
+]
+
+include-package-data = true
+
+[tool.setuptools.package-data]
+"core.schemas" = ["*.schema.json"]
+
 [tool.black]
 line-length = 88
 
 [tool.ruff]
 line-length = 88
-

--- a/src/core/schemas/__init__.py
+++ b/src/core/schemas/__init__.py
@@ -1,25 +1,25 @@
-"""Load JSON schemas for SGR sections."""
-
 from __future__ import annotations
-
 import json
-from pathlib import Path
+from importlib.resources import files
+from typing import Dict, Any
 
-BASE_DIR = Path(__file__).resolve().parent
+# Разрешённые имена схем (для явной валидации)
+SCHEMA_FILES = {
+    "container": "container.schema.json",
+    "business_overview": "business_overview.schema.json",
+    "legal_structure": "legal_structure.schema.json",
+    "financials": "financials.schema.json",
+    "legal_cases": "legal_cases.schema.json",
+    "news": "news.schema.json",
+    "assets_gallery": "assets_gallery.schema.json",
+}
 
-SCHEMA_NAMES = [
-    "business_overview",
-    "legal_structure",
-    "financials",
-    "legal_cases",
-    "news",
-    "assets_gallery",
-    "container",
-]
 
-SCHEMAS: dict[str, dict] = {}
-for name in SCHEMA_NAMES:
-    with (BASE_DIR / f"{name}.schema.json").open(encoding="utf-8") as f:
-        SCHEMAS[name] = json.load(f)
-
-__all__ = ["SCHEMAS", "SCHEMA_NAMES"]
+def load_schema(name: str) -> Dict[str, Any]:
+    """
+    Возвращает JSON-схему по короткому имени (например, 'financials').
+    """
+    if name not in SCHEMA_FILES:
+        raise KeyError(f"Unknown schema: {name}")
+    path = files(__package__).joinpath(SCHEMA_FILES[name])
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/src/core/schemas/assets_gallery.schema.json
+++ b/src/core/schemas/assets_gallery.schema.json
@@ -1,21 +1,17 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["assets", "source", "confidence"],
-  "properties": {
-    "assets": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["description", "url"],
-        "properties": {
-          "description": {"type": "string"},
-          "url": {"type": "string", "format": "uri"},
-          "valuation": {"type": "number", "minimum": 0}
-        }
-      }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/assets_gallery.schema.json",
+  "title": "AssetsGallery",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["caption", "url"],
+    "properties": {
+      "caption": { "type": "string" },
+      "url": { "type": "string", "format": "uri" },
+      "taken_at": { "type": ["string", "null"], "format": "date" },
+      "license": { "type": ["string", "null"] }
     },
-    "source": {"type": "string"},
-    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+    "additionalProperties": false
   }
 }

--- a/src/core/schemas/business_overview.schema.json
+++ b/src/core/schemas/business_overview.schema.json
@@ -1,20 +1,17 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/business_overview.schema.json",
+  "title": "BusinessOverview",
   "type": "object",
-  "required": [
-    "company_name",
-    "inn",
-    "ogrn",
-    "registration_date",
-    "source",
-    "confidence"
-  ],
+  "required": ["text", "sources", "confidence"],
   "properties": {
-    "company_name": {"type": "string"},
-    "inn": {"type": "string", "pattern": "^\\d{10}$"},
-    "ogrn": {"type": "string", "pattern": "^\\d{13}$"},
-    "registration_date": {"type": "string", "format": "date"},
-    "source": {"type": "string"},
-    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
-  }
+    "text": { "type": ["string", "null"], "maxLength": 2000 },
+    "sources": {
+      "type": "array",
+      "items": { "type": "string", "format": "uri" },
+      "minItems": 0
+    },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+  },
+  "additionalProperties": false
 }

--- a/src/core/schemas/container.schema.json
+++ b/src/core/schemas/container.schema.json
@@ -1,24 +1,35 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/container.schema.json",
+  "title": "CompanyContainer",
   "type": "object",
-  "required": [
-    "business_overview",
-    "legal_structure",
-    "financials",
-    "legal_cases",
-    "news",
-    "assets_gallery",
-    "source",
-    "confidence"
-  ],
+  "required": ["company_id", "resolved", "sections"],
   "properties": {
-    "business_overview": {"$ref": "business_overview.schema.json"},
-    "legal_structure": {"$ref": "legal_structure.schema.json"},
-    "financials": {"$ref": "financials.schema.json"},
-    "legal_cases": {"$ref": "legal_cases.schema.json"},
-    "news": {"$ref": "news.schema.json"},
-    "assets_gallery": {"$ref": "assets_gallery.schema.json"},
-    "source": {"type": "string"},
-    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
-  }
+    "company_id": { "type": "string" },
+    "resolved": {
+      "type": "object",
+      "required": ["names"],
+      "properties": {
+        "inn": { "type": ["string", "null"], "pattern": "^(\\d{10}|\\d{12})$" },
+        "ogrn": { "type": ["string", "null"], "pattern": "^(\\d{13}|\\d{15})$" },
+        "names": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "website": { "type": ["string", "null"], "format": "uri" }
+      },
+      "additionalProperties": false
+    },
+    "sections": {
+      "type": "object",
+      "required": ["business_overview", "legal_structure", "financials", "legal_cases", "news", "assets_gallery"],
+      "properties": {
+        "business_overview": { "type": "object" },
+        "legal_structure": { "type": "object" },
+        "financials": { "type": "array" },
+        "legal_cases": { "type": "array" },
+        "news": { "type": "array" },
+        "assets_gallery": { "type": "array" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/src/core/schemas/financials.schema.json
+++ b/src/core/schemas/financials.schema.json
@@ -1,12 +1,75 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["revenue", "profit", "reporting_date", "source", "confidence"],
-  "properties": {
-    "revenue": {"type": "number", "minimum": 0},
-    "profit": {"type": "number"},
-    "reporting_date": {"type": "string", "format": "date"},
-    "source": {"type": "string"},
-    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/financials.schema.json",
+  "title": "Financials",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "required": ["period", "currency", "pnl", "bs", "cf", "derived", "source", "confidence"],
+    "properties": {
+      "period": {
+        "type": "string",
+        "pattern": "^(FY\\d{4}|Q[1-4]Y\\d{4}|\\d{4}(-\\d{2})?)$"
+      },
+      "currency": { "type": "string", "minLength": 3, "maxLength": 3 },
+      "pnl": {
+        "type": "object",
+        "required": ["revenue", "cogs", "gross_profit", "ebit", "net_income"],
+        "properties": {
+          "revenue": { "type": ["number", "null"] },
+          "cogs": { "type": ["number", "null"] },
+          "gross_profit": { "type": ["number", "null"] },
+          "opex": { "type": ["number", "null"] },
+          "ebit": { "type": ["number", "null"] },
+          "net_income": { "type": ["number", "null"] }
+        },
+        "additionalProperties": false
+      },
+      "bs": {
+        "type": "object",
+        "required": ["total_assets", "inventory", "receivables", "payables", "cash", "st_debt", "lt_debt", "current_assets", "current_liabilities"],
+        "properties": {
+          "total_assets": { "type": ["number", "null"] },
+          "inventory": { "type": ["number", "null"] },
+          "receivables": { "type": ["number", "null"] },
+          "payables": { "type": ["number", "null"] },
+          "cash": { "type": ["number", "null"] },
+          "st_debt": { "type": ["number", "null"] },
+          "lt_debt": { "type": ["number", "null"] },
+          "current_assets": { "type": ["number", "null"] },
+          "current_liabilities": { "type": ["number", "null"] }
+        },
+        "additionalProperties": false
+      },
+      "cf": {
+        "type": "object",
+        "required": ["cfo", "cfi", "cff", "ending_cash"],
+        "properties": {
+          "cfo": { "type": ["number", "null"] },
+          "cfi": { "type": ["number", "null"] },
+          "cff": { "type": ["number", "null"] },
+          "ending_cash": { "type": ["number", "null"] }
+        },
+        "additionalProperties": false
+      },
+      "derived": {
+        "type": "object",
+        "required": ["net_debt", "nwc", "inv_days", "ar_days", "ap_days", "ebit_margin", "net_margin"],
+        "properties": {
+          "net_debt": { "type": ["number", "null"] },
+          "nwc": { "type": ["number", "null"] },
+          "inv_days": { "type": ["number", "null"] },
+          "ar_days": { "type": ["number", "null"] },
+          "ap_days": { "type": ["number", "null"] },
+          "ebit_margin": { "type": ["number", "null"] },
+          "net_margin": { "type": ["number", "null"] }
+        },
+        "additionalProperties": false
+      },
+      "source": { "type": "string", "format": "uri" },
+      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+    },
+    "additionalProperties": false
   }
 }

--- a/src/core/schemas/legal_cases.schema.json
+++ b/src/core/schemas/legal_cases.schema.json
@@ -1,21 +1,22 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["cases", "source", "confidence"],
-  "properties": {
-    "cases": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["case_number", "decision_date", "status"],
-        "properties": {
-          "case_number": {"type": "string"},
-          "decision_date": {"type": "string", "format": "date"},
-          "status": {"type": "string", "enum": ["open", "closed"]}
-        }
-      }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/legal_cases.schema.json",
+  "title": "LegalCases",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["case_id", "court", "date", "role", "subject", "stage", "url", "confidence"],
+    "properties": {
+      "case_id": { "type": "string" },
+      "court": { "type": "string" },
+      "date": { "type": "string", "format": "date" },
+      "role": { "type": "string", "enum": ["plaintiff", "defendant", "third_party"] },
+      "subject": { "type": "string" },
+      "stage": { "type": "string" },
+      "amount": { "type": ["number", "null"] },
+      "url": { "type": "string", "format": "uri" },
+      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
     },
-    "source": {"type": "string"},
-    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+    "additionalProperties": false
   }
 }

--- a/src/core/schemas/legal_structure.schema.json
+++ b/src/core/schemas/legal_structure.schema.json
@@ -1,20 +1,47 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/legal_structure.schema.json",
+  "title": "LegalStructure",
   "type": "object",
-  "required": ["owners", "source", "confidence"],
+  "required": ["nodes", "edges", "sources", "confidence"],
   "properties": {
-    "owners": {
+    "nodes": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["name", "share"],
+        "required": ["id", "type", "label"],
         "properties": {
-          "name": {"type": "string"},
-          "share": {"type": "number", "minimum": 0, "maximum": 100}
-        }
+          "id": { "type": "string" },
+          "type": { "type": "string", "enum": ["HoldCo", "OpCo", "SPV", "Person"] },
+          "label": { "type": "string" },
+          "inn": { "type": ["string", "null"], "pattern": "^(\\d{10}|\\d{12})$" },
+          "ogrn": { "type": ["string", "null"], "pattern": "^(\\d{13}|\\d{15})$" },
+          "status": { "type": ["string", "null"] }
+        },
+        "additionalProperties": false
       }
     },
-    "source": {"type": "string"},
-    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
-  }
+    "edges": {
+      "type": "array",
+      "minItems": 0,
+      "items": {
+        "type": "object",
+        "required": ["from", "to", "relation"],
+        "properties": {
+          "from": { "type": "string" },
+          "to": { "type": "string" },
+          "relation": { "type": "string", "enum": ["owns", "controls", "pledge"] },
+          "share": { "type": ["number", "null"], "minimum": 0, "maximum": 100 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": { "type": "string", "format": "uri" }
+    },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
+  },
+  "additionalProperties": false
 }

--- a/src/core/schemas/news.schema.json
+++ b/src/core/schemas/news.schema.json
@@ -1,20 +1,22 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "required": ["items", "source", "confidence"],
-  "properties": {
-    "items": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["headline", "date"],
-        "properties": {
-          "headline": {"type": "string"},
-          "date": {"type": "string", "format": "date"}
-        }
-      }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/news.schema.json",
+  "title": "News",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["date", "title", "category", "url", "summary", "confidence"],
+    "properties": {
+      "date": { "type": "string", "format": "date" },
+      "title": { "type": "string" },
+      "category": {
+        "type": "string",
+        "enum": ["incident", "contract", "M&A", "sanctions", "ESG", "HR", "other"]
+      },
+      "url": { "type": "string", "format": "uri" },
+      "summary": { "type": "string" },
+      "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
     },
-    "source": {"type": "string"},
-    "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+    "additionalProperties": false
   }
 }

--- a/tests/test_schemas_valid.py
+++ b/tests/test_schemas_valid.py
@@ -9,391 +9,263 @@ import pytest
 # allow importing from src
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from core.schemas import SCHEMAS  # noqa: E402
-
-SCHEMA_DIR = Path(__file__).resolve().parents[1] / "src" / "core" / "schemas"
-
-
-def _resolver(name: str) -> jsonschema.RefResolver:
-    schema_path = SCHEMA_DIR / f"{name}.schema.json"
-    return jsonschema.RefResolver(base_uri=schema_path.as_uri(), referrer=SCHEMAS[name])
-
+from core.schemas import load_schema  # noqa: E402
 
 FORMAT_CHECKER = jsonschema.FormatChecker()
 
+BUSINESS_OVERVIEW_VALID = {
+    "text": "Some overview",
+    "sources": ["https://example.com"],
+    "confidence": 0.9,
+}
+BUSINESS_OVERVIEW_INVALID = {
+    "text": "Bad confidence",
+    "sources": ["https://example.com"],
+    "confidence": 2,
+}
+
+LEGAL_STRUCTURE_VALID = {
+    "nodes": [
+        {
+            "id": "n1",
+            "type": "HoldCo",
+            "label": "HoldCo LLC",
+            "inn": "1234567890",
+            "ogrn": "1234567890123",
+            "status": None,
+        },
+        {"id": "n2", "type": "OpCo", "label": "OpCo LLC"},
+    ],
+    "edges": [{"from": "n1", "to": "n2", "relation": "owns", "share": 100}],
+    "sources": ["https://example.com"],
+    "confidence": 0.8,
+}
+LEGAL_STRUCTURE_INVALID = {
+    "nodes": [
+        {
+            "id": "n1",
+            "type": "HoldCo",
+            "label": "HoldCo LLC",
+            "inn": "1234",
+        }
+    ],
+    "edges": [],
+    "sources": ["https://example.com"],
+    "confidence": 0.8,
+}
+
+FINANCIALS_VALID = [
+    {
+        "period": "FY2023",
+        "currency": "USD",
+        "pnl": {
+            "revenue": 100,
+            "cogs": 50,
+            "gross_profit": 50,
+            "opex": 10,
+            "ebit": 40,
+            "net_income": 30,
+        },
+        "bs": {
+            "total_assets": 200,
+            "inventory": 10,
+            "receivables": 20,
+            "payables": 15,
+            "cash": 5,
+            "st_debt": 0,
+            "lt_debt": 0,
+            "current_assets": 50,
+            "current_liabilities": 20,
+        },
+        "cf": {
+            "cfo": 40,
+            "cfi": -10,
+            "cff": 0,
+            "ending_cash": 5,
+        },
+        "derived": {
+            "net_debt": -5,
+            "nwc": 30,
+            "inv_days": 10,
+            "ar_days": 20,
+            "ap_days": 30,
+            "ebit_margin": 0.4,
+            "net_margin": 0.3,
+        },
+        "source": "https://example.com/fin",
+        "confidence": 0.9,
+    }
+]
+FINANCIALS_INVALID = [
+    {
+        "period": "FY2023",
+        "currency": "US",
+        "pnl": {
+            "revenue": 100,
+            "cogs": 50,
+            "gross_profit": 50,
+            "opex": 10,
+            "ebit": 40,
+            "net_income": 30,
+        },
+        "bs": {
+            "total_assets": 200,
+            "inventory": 10,
+            "receivables": 20,
+            "payables": 15,
+            "cash": 5,
+            "st_debt": 0,
+            "lt_debt": 0,
+            "current_assets": 50,
+            "current_liabilities": 20,
+        },
+        "cf": {
+            "cfo": 40,
+            "cfi": -10,
+            "cff": 0,
+            "ending_cash": 5,
+        },
+        "derived": {
+            "net_debt": -5,
+            "nwc": 30,
+            "inv_days": 10,
+            "ar_days": 20,
+            "ap_days": 30,
+            "ebit_margin": 0.4,
+            "net_margin": 0.3,
+        },
+        "source": "https://example.com/fin",
+        "confidence": 0.9,
+    }
+]
+
+LEGAL_CASES_VALID = [
+    {
+        "case_id": "1",
+        "court": "Court",
+        "date": "2024-01-01",
+        "role": "plaintiff",
+        "subject": "Subject",
+        "stage": "ongoing",
+        "amount": 1000,
+        "url": "https://example.com/case",
+        "confidence": 0.9,
+    }
+]
+LEGAL_CASES_INVALID = [
+    {
+        "case_id": "1",
+        "court": "Court",
+        "date": "2024-01-01",
+        "role": "owner",
+        "subject": "Subject",
+        "stage": "ongoing",
+        "url": "https://example.com/case",
+        "confidence": 0.9,
+    }
+]
+
+NEWS_VALID = [
+    {
+        "date": "2024-01-01",
+        "title": "Title",
+        "category": "incident",
+        "url": "https://example.com/news",
+        "summary": "Summary",
+        "confidence": 0.5,
+    }
+]
+NEWS_INVALID = [
+    {
+        "date": "2024-01-01",
+        "title": "Title",
+        "category": "unknown",
+        "url": "https://example.com/news",
+        "summary": "Summary",
+        "confidence": 0.5,
+    }
+]
+
+ASSETS_GALLERY_VALID = [
+    {
+        "caption": "Photo",
+        "url": "https://example.com/photo.jpg",
+        "taken_at": None,
+        "license": None,
+    }
+]
+ASSETS_GALLERY_INVALID = [{"caption": "Photo"}]
+
+CONTAINER_VALID = {
+    "company_id": "comp1",
+    "resolved": {
+        "inn": "1234567890",
+        "ogrn": "1234567890123",
+        "names": ["Name LLC"],
+        "website": "https://example.com",
+    },
+    "sections": {
+        "business_overview": BUSINESS_OVERVIEW_VALID,
+        "legal_structure": LEGAL_STRUCTURE_VALID,
+        "financials": FINANCIALS_VALID,
+        "legal_cases": LEGAL_CASES_VALID,
+        "news": NEWS_VALID,
+        "assets_gallery": ASSETS_GALLERY_VALID,
+    },
+}
+CONTAINER_INVALID = [
+    {
+        "company_id": "comp1",
+        "resolved": {
+            "inn": "123",
+            "ogrn": "1234567890123",
+            "names": ["Name LLC"],
+            "website": "https://example.com",
+        },
+        "sections": {
+            "business_overview": BUSINESS_OVERVIEW_VALID,
+            "legal_structure": LEGAL_STRUCTURE_VALID,
+            "financials": FINANCIALS_VALID,
+            "legal_cases": LEGAL_CASES_VALID,
+            "news": NEWS_VALID,
+            "assets_gallery": ASSETS_GALLERY_VALID,
+        },
+    },
+    {
+        "company_id": "comp1",
+        "resolved": {
+            "inn": "1234567890",
+            "ogrn": "1234567890123",
+            "names": ["Name LLC"],
+            "website": "https://example.com",
+        },
+        "sections": {
+            "business_overview": BUSINESS_OVERVIEW_VALID,
+            "legal_structure": LEGAL_STRUCTURE_VALID,
+            "financials": FINANCIALS_VALID,
+            "legal_cases": LEGAL_CASES_VALID,
+            "assets_gallery": ASSETS_GALLERY_VALID,
+        },
+    },
+]
 
 EXAMPLES = {
     "business_overview": {
-        "valid": [
-            {
-                "company_name": "ABC Ltd",
-                "inn": "1234567890",
-                "ogrn": "1234567890123",
-                "registration_date": "2020-01-01",
-                "source": "registry",
-                "confidence": 0.9,
-            },
-            {
-                "company_name": "XYZ LLC",
-                "inn": "9876543210",
-                "ogrn": "9876543210987",
-                "registration_date": "2021-12-31",
-                "source": "registry",
-                "confidence": 0.8,
-            },
-            {
-                "company_name": "Foo Bar",
-                "inn": "1020304050",
-                "ogrn": "1231231231231",
-                "registration_date": "2022-05-20",
-                "source": "manual",
-                "confidence": 1,
-            },
-        ],
-        "invalid": [
-            {
-                "company_name": "Bad Inn",
-                "inn": "12345",
-                "ogrn": "1234567890123",
-                "registration_date": "2020-01-01",
-                "source": "registry",
-                "confidence": 0.9,
-            },
-            {
-                "company_name": "Missing OGRN",
-                "inn": "1234567890",
-                "registration_date": "2020-01-01",
-                "source": "registry",
-                "confidence": 0.9,
-            },
-            {
-                "company_name": "Bad Date",
-                "inn": "1234567890",
-                "ogrn": "1234567890123",
-                "registration_date": "01-01-2020",
-                "source": "registry",
-                "confidence": 0.9,
-            },
-        ],
+        "valid": [BUSINESS_OVERVIEW_VALID],
+        "invalid": [BUSINESS_OVERVIEW_INVALID],
     },
     "legal_structure": {
-        "valid": [
-            {
-                "owners": [
-                    {"name": "Owner1", "share": 60},
-                    {"name": "Owner2", "share": 40},
-                ],
-                "source": "statements",
-                "confidence": 0.7,
-            },
-            {
-                "owners": [{"name": "Owner", "share": 100}],
-                "source": "statements",
-                "confidence": 1,
-            },
-            {
-                "owners": [
-                    {"name": "A", "share": 33.3},
-                    {"name": "B", "share": 66.7},
-                ],
-                "source": "registry",
-                "confidence": 0.5,
-            },
-        ],
-        "invalid": [
-            {
-                "owners": [{"name": "Owner1", "share": 150}],
-                "source": "statements",
-                "confidence": 0.7,
-            },
-            {
-                "owners": [{"share": 50}],
-                "source": "statements",
-                "confidence": 0.7,
-            },
-            {
-                "source": "statements",
-                "confidence": 0.7,
-            },
-        ],
+        "valid": [LEGAL_STRUCTURE_VALID],
+        "invalid": [LEGAL_STRUCTURE_INVALID],
     },
-    "financials": {
-        "valid": [
-            {
-                "revenue": 1000,
-                "profit": 100,
-                "reporting_date": "2023-12-31",
-                "source": "report",
-                "confidence": 0.9,
-            },
-            {
-                "revenue": 0,
-                "profit": 0,
-                "reporting_date": "2022-06-30",
-                "source": "report",
-                "confidence": 0.8,
-            },
-            {
-                "revenue": 500,
-                "profit": -50,
-                "reporting_date": "2021-01-01",
-                "source": "audit",
-                "confidence": 0.6,
-            },
-        ],
-        "invalid": [
-            {
-                "revenue": -1,
-                "profit": 10,
-                "reporting_date": "2023-12-31",
-                "source": "report",
-                "confidence": 0.9,
-            },
-            {
-                "revenue": 100,
-                "profit": 10,
-                "source": "report",
-                "confidence": 0.9,
-            },
-            {
-                "revenue": 100,
-                "profit": 10,
-                "reporting_date": "31-12-2023",
-                "source": "report",
-                "confidence": 0.9,
-            },
-        ],
-    },
-    "legal_cases": {
-        "valid": [
-            {
-                "cases": [
-                    {
-                        "case_number": "A1",
-                        "decision_date": "2023-03-01",
-                        "status": "open",
-                    }
-                ],
-                "source": "courts",
-                "confidence": 0.4,
-            },
-            {
-                "cases": [
-                    {
-                        "case_number": "B2",
-                        "decision_date": "2020-11-15",
-                        "status": "closed",
-                    }
-                ],
-                "source": "courts",
-                "confidence": 0.8,
-            },
-            {
-                "cases": [
-                    {
-                        "case_number": "C3",
-                        "decision_date": "2022-07-07",
-                        "status": "open",
-                    },
-                    {
-                        "case_number": "D4",
-                        "decision_date": "2021-05-05",
-                        "status": "closed",
-                    },
-                ],
-                "source": "courts",
-                "confidence": 0.9,
-            },
-        ],
-        "invalid": [
-            {
-                "cases": [
-                    {
-                        "case_number": "E5",
-                        "decision_date": "2023-01-01",
-                        "status": "pending",
-                    }
-                ],
-                "source": "courts",
-                "confidence": 0.5,
-            },
-            {
-                "cases": [{"decision_date": "2023-01-01", "status": "open"}],
-                "source": "courts",
-                "confidence": 0.5,
-            },
-            {
-                "source": "courts",
-                "confidence": 0.5,
-            },
-        ],
-    },
-    "news": {
-        "valid": [
-            {
-                "items": [{"headline": "News 1", "date": "2023-01-01"}],
-                "source": "media",
-                "confidence": 0.7,
-            },
-            {
-                "items": [
-                    {"headline": "News 2", "date": "2022-12-12"},
-                    {"headline": "News 3", "date": "2022-12-13"},
-                ],
-                "source": "media",
-                "confidence": 0.6,
-            },
-            {
-                "items": [{"headline": "Another", "date": "2020-05-05"}],
-                "source": "media",
-                "confidence": 1,
-            },
-        ],
-        "invalid": [
-            {
-                "items": [{"date": "2023-01-01"}],
-                "source": "media",
-                "confidence": 0.7,
-            },
-            {
-                "items": [{"headline": "Bad Date", "date": "01-01-2023"}],
-                "source": "media",
-                "confidence": 0.7,
-            },
-            {
-                "source": "media",
-                "confidence": 0.7,
-            },
-        ],
-    },
+    "financials": {"valid": [FINANCIALS_VALID], "invalid": [FINANCIALS_INVALID]},
+    "legal_cases": {"valid": [LEGAL_CASES_VALID], "invalid": [LEGAL_CASES_INVALID]},
+    "news": {"valid": [NEWS_VALID], "invalid": [NEWS_INVALID]},
     "assets_gallery": {
-        "valid": [
-            {
-                "assets": [
-                    {
-                        "description": "Car",
-                        "url": "http://example.com/car.jpg",
-                        "valuation": 10000,
-                    }
-                ],
-                "source": "inventory",
-                "confidence": 0.9,
-            },
-            {
-                "assets": [
-                    {
-                        "description": "House",
-                        "url": "https://example.com/house.png",
-                    }
-                ],
-                "source": "inventory",
-                "confidence": 0.8,
-            },
-            {
-                "assets": [
-                    {
-                        "description": "Boat",
-                        "url": "http://example.com/boat.jpg",
-                        "valuation": 0,
-                    }
-                ],
-                "source": "inventory",
-                "confidence": 0.6,
-            },
-        ],
-        "invalid": [
-            {
-                "assets": [{"description": "Car", "valuation": 10000}],
-                "source": "inventory",
-                "confidence": 0.9,
-            },
-            {
-                "assets": [
-                    {
-                        "description": "Car",
-                        "url": "http://example.com/car.jpg",
-                        "valuation": -100,
-                    }
-                ],
-                "source": "inventory",
-                "confidence": 0.9,
-            },
-            {
-                "source": "inventory",
-                "confidence": 0.9,
-            },
-        ],
+        "valid": [ASSETS_GALLERY_VALID],
+        "invalid": [ASSETS_GALLERY_INVALID],
     },
-}
-
-# build container examples using previous ones
-EXAMPLES["container"] = {
-    "valid": [
-        {
-            "business_overview": EXAMPLES["business_overview"]["valid"][0],
-            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
-            "financials": EXAMPLES["financials"]["valid"][0],
-            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
-            "news": EXAMPLES["news"]["valid"][0],
-            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
-            "source": "container",
-            "confidence": 0.9,
-        },
-        {
-            "business_overview": EXAMPLES["business_overview"]["valid"][1],
-            "legal_structure": EXAMPLES["legal_structure"]["valid"][1],
-            "financials": EXAMPLES["financials"]["valid"][1],
-            "legal_cases": EXAMPLES["legal_cases"]["valid"][1],
-            "news": EXAMPLES["news"]["valid"][1],
-            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][1],
-            "source": "container",
-            "confidence": 0.8,
-        },
-        {
-            "business_overview": EXAMPLES["business_overview"]["valid"][2],
-            "legal_structure": EXAMPLES["legal_structure"]["valid"][2],
-            "financials": EXAMPLES["financials"]["valid"][2],
-            "legal_cases": EXAMPLES["legal_cases"]["valid"][2],
-            "news": EXAMPLES["news"]["valid"][2],
-            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][2],
-            "source": "container",
-            "confidence": 1,
-        },
-    ],
-    "invalid": [
-        {
-            # missing news
-            "business_overview": EXAMPLES["business_overview"]["valid"][0],
-            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
-            "financials": EXAMPLES["financials"]["valid"][0],
-            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
-            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
-            "source": "container",
-            "confidence": 0.9,
-        },
-        {
-            # invalid business_overview
-            "business_overview": EXAMPLES["business_overview"]["invalid"][0],
-            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
-            "financials": EXAMPLES["financials"]["valid"][0],
-            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
-            "news": EXAMPLES["news"]["valid"][0],
-            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
-            "source": "container",
-            "confidence": 0.9,
-        },
-        {
-            # confidence out of range
-            "business_overview": EXAMPLES["business_overview"]["valid"][0],
-            "legal_structure": EXAMPLES["legal_structure"]["valid"][0],
-            "financials": EXAMPLES["financials"]["valid"][0],
-            "legal_cases": EXAMPLES["legal_cases"]["valid"][0],
-            "news": EXAMPLES["news"]["valid"][0],
-            "assets_gallery": EXAMPLES["assets_gallery"]["valid"][0],
-            "source": "container",
-            "confidence": 1.5,
-        },
-    ],
+    "container": {"valid": [CONTAINER_VALID], "invalid": CONTAINER_INVALID},
 }
 
 
@@ -402,13 +274,8 @@ EXAMPLES["container"] = {
     [(name, ex) for name, data in EXAMPLES.items() for ex in data["valid"]],
 )
 def test_valid_examples(schema_name: str, example: dict) -> None:
-    resolver = _resolver(schema_name)
-    jsonschema.validate(
-        example,
-        SCHEMAS[schema_name],
-        resolver=resolver,
-        format_checker=FORMAT_CHECKER,
-    )
+    schema = load_schema(schema_name)
+    jsonschema.validate(example, schema, format_checker=FORMAT_CHECKER)
 
 
 @pytest.mark.parametrize(
@@ -416,11 +283,6 @@ def test_valid_examples(schema_name: str, example: dict) -> None:
     [(name, ex) for name, data in EXAMPLES.items() for ex in data["invalid"]],
 )
 def test_invalid_examples(schema_name: str, example: dict) -> None:
-    resolver = _resolver(schema_name)
+    schema = load_schema(schema_name)
     with pytest.raises(jsonschema.ValidationError):
-        jsonschema.validate(
-            example,
-            SCHEMAS[schema_name],
-            resolver=resolver,
-            format_checker=FORMAT_CHECKER,
-        )
+        jsonschema.validate(example, schema, format_checker=FORMAT_CHECKER)


### PR DESCRIPTION
## Summary
- package core JSON schemas and expose via `load_schema`
- ship schemas as package data and load with `importlib.resources`
- add validation tests for all schema sections

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c56d26554c83228d43a2e4c5cb84c2